### PR TITLE
update content type logic to check if header includes image/gif rathe…

### DIFF
--- a/src/parse-generate.js
+++ b/src/parse-generate.js
@@ -15,7 +15,7 @@ const validateAndFix = (gif) => {
 export const parse = (src, { signal }) =>
   fetch(src, { signal })
     .then((resp) => {
-      if (resp.headers.get("Content-Type") !== "image/gif")
+      if (!resp.headers.get("Content-Type").includes("image/gif"))
         throw Error(
           `Wrong content type: "${resp.headers.get("Content-Type")}"`
         );


### PR DESCRIPTION
Update parse-generate logic to check if header Content-Type includes image/gif vs strictly checking for image/gif. AWS with Chrome has an issue when uploading via the browser where the Content-Type gets ; charset=UTF-8 appended https://github.com/aws/aws-sdk-js/issues/1011

By checking if the Content-Type includes image/gif it makes the logic more robust without being too loose.